### PR TITLE
added ability to set a hostgroup by matching the hostname with regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,21 +17,23 @@ for how to install Foreman plugins
 
 ## Usage
 
-Go to `Settings -> DefaultHostgroup` and enter the name of the default
-hostgroup. Leaving this blank disables the plugin. Nested Hostgroups should be
-specified with the full label, e.g. `Base/Level1/Level2`
+The configuration is done inside foreman's plugin settings directory which is ```~foreman/config/settings.plugins.d/```.
 
-Once set, any fact upload to `/api/hosts/facts` for a Host with no Hostgroup set
-will cause the Hostgroup to be set to the value in the Settings. This happens
-*before* the ENC data is downloaded, meaning it applies for a Host's very first
-run.
+You can simply copy ```default_hostgroup.yaml.example``` and adjust it to fit your needs. You should change the example settings as they might break your setup (very unlikely though).
 
-The plugin only sets the Hostgroup for Hosts which have no Hostgroup, and no
-reports (i.e new Hosts only).
+*Important Note:* You have to restart foreman in order to apply changes in ```default_hostgroup.yaml```!
+
+There are also two more settings under ```Settings -> DefaultHostgroup```
+
+| Setting | Description |
+| ------- | ----------- |
+| ```force_hostgroup_match``` | Setting this to ```true``` will perform matching even on hosts that already have a hostgroup set. Enabling this needs ```force_hostgroup_match_only_new``` to be ```false```.  Default: ```false``` |
+| ```force_hostgroup_match_only_new``` | Setting this to ```true``` will only perform matching when a host uploads its facts for the first time, i.e. after provisioning or when adding an existing puppetmaster and thus its nodes into foreman. Default: ```true``` |
+
 
 ## TODO
 
-* Tests
+* Deface the Hostgroup UI to add the regular expressions directly into the Hostgroup
 
 ## Contributing
 

--- a/app/models/setting/default_hostgroup.rb
+++ b/app/models/setting/default_hostgroup.rb
@@ -7,7 +7,8 @@ class Setting::DefaultHostgroup < ::Setting
 
       Setting.transaction do
         [
-          self.set('default_hostgroup', 'The default Hostgroup to place new Hosts in', ''),
+          self.set('force_hostgroup_match', 'Apply hostgroup matching even if a host already has one.', false),
+          self.set('force_hostgroup_match_only_new', 'Apply hostgroup matching only on new hosts', true),
         ].compact.each { |s| self.create s.update(:category => 'Setting::DefaultHostgroup')}
       end
 

--- a/default_hostgroup.yaml.example
+++ b/default_hostgroup.yaml.example
@@ -1,0 +1,21 @@
+# Example default_hostgroup settings
+#
+# Must be placed in ~foreman/config/settings.plugins.d/
+#
+# :map:
+#   <hostgroup>:    <regex>
+#
+# The regex can be written either with or without the enclosing slashes:
+#   ^test$      - valid
+#   /^test$/    - also valid
+#
+#
+---
+:default_hostgroup:
+    :map:
+        "Internal":         \.local$
+        "Core Services":    \.core.my-company.net$
+        "Customers/Foobar"  \.foobar.customers.my-company.net$
+        "Webserver":        ^www\d*\.
+        "Mailserver":       ^mx\d*\.
+        "Default":          .*

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -1,36 +1,55 @@
-require 'yaml'
 module DefaultHostgroupManagedHostPatch
   def self.included(base)
     base.extend ClassMethods
     base.class_eval do
       class << self
-        alias_method_chain :importHostAndFacts, :apply_hostgroup
+        alias_method_chain :importHostAndFacts, :match_hostgroup
       end
     end
   end
 
   module ClassMethods
-    def importHostAndFacts_with_apply_hostgroup hostname, facts, certname = nil, proxy_id = nil
-      host, result = importHostAndFacts_without_apply_hostgroup(hostname, facts, certname, proxy_id)
-      Rails.logger.debug "DefaultHostgroup: performing Hostgroup check"
+    def importHostAndFacts_with_match_hostgroup hostname, facts, certname = nil, proxy_id = nil
+      raise Foreman::Exception.new "Could not load default_hostgroup settings, check config" unless SETTINGS[:default_hostgroup]
+      raise Foreman::Exception.new "Could not load default_hostgroup map from settings, check config." unless SETTINGS[:default_hostgroup][:map]
 
-      unless valid_hostgroup?
-        Rails.logger.debug "DefaultHostgroup: Could not find Hostgroup '#{Setting[:default_hostgroup]}'"
-        return host, result
+      Rails.logger.debug "DefaultHostgroupMatch: performing Hostgroup match"
+      host, result = importHostAndFacts_without_match_hostgroup(hostname, facts, certname, proxy_id)
+
+      if Setting[:force_hostgroup_match_only_new]
+        return host, result unless host.present? && !host.new_record? && host.hostgroup.nil? && host.reports.empty?
       end
 
-      # host.new_record? will only test for the early return in the core method, a real host
-      # will have already been saved at least once.
-      if host.present? && !host.new_record? && host.hostgroup.nil? && host.reports.empty?
-        host.hostgroup = Hostgroup.find_by_label(Setting[:default_hostgroup])
-        host.save(:validate => false)
-        Rails.logger.debug "DefaultHostgroup: added #{host.name} to #{host.hostgroup.label}"
+      unless Setting[:force_hostgroup_match]
+        return host, result if host.hostgroup
       end
+
+      map = SETTINGS[:default_hostgroup][:map]
+      new_hostgroup = nil
+
+      map.each do |hostgroup, regex|
+        unless valid_hostgroup?(hostgroup)
+          Rails.logger.error "DefaultHostgroupMatch: #{hostgroup} is not a valid hostgroup, skipping."
+          next
+        end
+        regex.gsub!(/(\A\/|\/\z)/, '')
+        if Regexp.new(regex).match(hostname)
+          new_hostgroup = Hostgroup.find_by_label(hostgroup)
+          break
+        end
+      end
+
+      return host, result unless new_hostgroup
+
+      host.hostgroup = new_hostgroup
+      host.save(:validate => false)
+      Rails.logger.info "DefaultHostgroupMatch: #{hostname} added to #{new_hostgroup}"
+
       return host, result
     end
 
-    def valid_hostgroup?
-      Hostgroup.find_by_label(Setting[:default_hostgroup]) ? true : false
+    def valid_hostgroup?(hostgroup)
+      Hostgroup.find_by_label(hostgroup) ? true : false
     end
   end
 end


### PR DESCRIPTION
This adds the functionallity to add hosts to hostgroups matching their hostname on a regex pattern.

There is currently only a simple yaml file to create the matching map, this should be moved in the hostgroup section or something.

I think the best place would be if we would add some new fields into the hostgroup UI like in the puppetclasses where you can add match values.
