### PR TITLE
Use Regex against Facts for setting default hostgroup

### DIFF
--- a/default_hostgroup.yaml.example
+++ b/default_hostgroup.yaml.example
@@ -2,20 +2,23 @@
 #
 # Must be placed in ~foreman/config/settings.plugins.d/
 #
-# :map:
-#   <hostgroup>:    <regex>
+# :facts_map:
+#   :<hostgroup>:
+#     :<fact_name>: <regex>
 #
 # The regex can be written either with or without the enclosing slashes:
 #   ^test$      - valid
 #   /^test$/    - also valid
 #
+# List the regexes in the order of prority
 #
 ---
+---
 :default_hostgroup:
-    :map:
-        "Internal":         \.local$
-        "Core Services":    \.core.my-company.net$
-        "Customers/Foobar"  \.foobar.customers.my-company.net$
-        "Webserver":        ^www\d*\.
-        "Mailserver":       ^mx\d*\.
-        "Default":          .*
+  :facts_map:
+    :redhat
+      "osfamily": "RedHat"
+    :osx:
+      "osfamily": "Darwin"
+    :catchall:
+      "hostname": ".*"

--- a/default_hostgroup.yaml.example
+++ b/default_hostgroup.yaml.example
@@ -3,8 +3,8 @@
 # Must be placed in ~foreman/config/settings.plugins.d/
 #
 # :facts_map:
-#   :<hostgroup>:
-#     :<fact_name>: <regex>
+#   <hostgroup>:
+#     <fact_name>: <regex>
 #
 # The regex can be written either with or without the enclosing slashes:
 #   ^test$      - valid

--- a/default_hostgroup.yaml.example
+++ b/default_hostgroup.yaml.example
@@ -16,9 +16,9 @@
 ---
 :default_hostgroup:
   :facts_map:
-    :redhat
+    "redhat base":
       "osfamily": "RedHat"
-    :osx:
+    "osx/common":
       "osfamily": "Darwin"
-    :catchall:
+    "catchall":
       "hostname": ".*"

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -67,6 +67,7 @@ module DefaultHostgroupManagedHostPatch
         else
           Rails.logger.info "No match found for #{@host.name}"
           return false
+        end
       end
     end
 

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -11,8 +11,7 @@ module DefaultHostgroupManagedHostPatch
   module ClassMethods
     def import_host_and_facts_with_match_hostgroup hostname, facts, certname = nil, proxy_id = nil
       host, result = import_host_and_facts_without_match_hostgroup(hostname, facts, certname, proxy_id)
-      facts_map = SETTINGS[:default_hostgroup][:facts_map]
-      Rails.logger.debug "Facts Map contains #{facts_map}"
+
       unless SETTINGS[:default_hostgroup] && SETTINGS[:default_hostgroup][:map]
         Rails.logger.warn "DefaultHostgroupMatch: Could not load default_hostgroup map from settings, check config."
         return host, result

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -61,7 +61,7 @@ module DefaultHostgroupManagedHostPatch
 
     def find_match(facts_map)
       facts_map.each do |group, fact|
-        return Hostgroup.find_by_title(hostgroup) if group_matches?(fact) and valid_hostgroup?(group)
+        return Hostgroup.find_by_title(group) if group_matches?(fact) and valid_hostgroup?(group)
       end
     end
 

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -38,7 +38,6 @@ module DefaultHostgroupManagedHostPatch
 
       facts_map = SETTINGS[:default_hostgroup][:facts_map]
       new_hostgroup = find_match(facts_map)
-      puts new_hostgroup.inspect
 
       return @host, result unless new_hostgroup
 

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -61,8 +61,12 @@ module DefaultHostgroupManagedHostPatch
     end
 
     def find_match(facts_map)
-      facts_map.each do |group, facts|
-        return Hostgroup.find_by_title(group) if group_matches?(facts) and valid_hostgroup?(group)
+      facts_map.each do |group_name, facts|
+        if group_matches?(facts) and valid_hostgroup?(group_name)
+          return Hostgroup.find_by_title(group_name)
+        else
+          Rails.logger.info "No match found for #{@host.name}"
+          return false
       end
     end
 

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -54,7 +54,7 @@ module DefaultHostgroupManagedHostPatch
       # end
 
       # Add some method for determining which match wins.
-      catch "FoundMatch"
+      catch "FoundMatch" do
         facts_map.each do |group, fact|
           Rails.logger.info "Hostgroup = #{group}"
           fact.each do |fact_name, fact_regex|

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -11,7 +11,8 @@ module DefaultHostgroupManagedHostPatch
   module ClassMethods
     def import_host_and_facts_with_match_hostgroup hostname, facts, certname = nil, proxy_id = nil
       host, result = import_host_and_facts_without_match_hostgroup(hostname, facts, certname, proxy_id)
-
+      Rails.logger.debug SETTINGS[:default_hostgroup][:map]
+      Rails.logger.debug SETTINGS[:default_hostgroup][:facts_map]
       unless SETTINGS[:default_hostgroup] && SETTINGS[:default_hostgroup][:map]
         Rails.logger.warn "DefaultHostgroupMatch: Could not load default_hostgroup map from settings, check config."
         return host, result

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -61,7 +61,7 @@ module DefaultHostgroupManagedHostPatch
             Rails.logger.info "Fact = #{fact_name}"
             Rails.logger.info "Regex = #{fact_regex}"
           if Regexp.new(fact_regex).match(host_fact_value)
-            Rails.logger.info "#{host_fact_value} matches ${fact_regex}"
+            Rails.logger.info "#{host_fact_value} matches #{fact_regex}"
           end
         end
       end

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -36,24 +36,9 @@ module DefaultHostgroupManagedHostPatch
         end
       end
 
-      # map = SETTINGS[:default_hostgroup][:map]
       facts_map = SETTINGS[:default_hostgroup][:facts_map]
       new_hostgroup = nil
 
-
-      # map.each do |hostgroup, regex|
-      #   unless valid_hostgroup?(hostgroup)
-      #     Rails.logger.error "DefaultHostgroupMatch: #{hostgroup} is not a valid hostgroup, skipping."
-      #     next
-      #   end
-      #   regex.gsub!(/(\A\/|\/\z)/, '')
-      #   if Regexp.new(regex).match(hostname)
-      #     new_hostgroup = Hostgroup.find_by_title(hostgroup)
-      #     break
-      #   end
-      # end
-
-      # Add some method for determining which match wins.
       catch (:foundmatch) do
         facts_map.each do |group, fact|
           Rails.logger.info "Hostgroup = #{group}"

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -39,23 +39,6 @@ module DefaultHostgroupManagedHostPatch
       facts_map = SETTINGS[:default_hostgroup][:facts_map]
       new_hostgroup = find_match(facts_map)
 
-      def find_match(facts_map)
-        facts_map.each do |group, fact|
-          return Hostgroup.find_by_title(hostgroup) if group_matches?(fact) and valid_hostgroup?(group)
-        end
-      end
-
-      def group_matches?(fact)
-        fact.each do |fact_name, fact_regex|
-          fact_regex.gsub!(/(\A\/|\/\z)/, '')
-          host_fact_value = host.facts_hash[fact_name]
-          Rails.logger.info "Fact = #{fact_name}"
-          Rails.logger.info "Regex = #{fact_regex}"
-          return true if Regexp.new(fact_regex).match(host_fact_value)
-        end
-        return false
-      end
-
       return host, result unless new_hostgroup
 
       host.hostgroup = new_hostgroup
@@ -63,6 +46,23 @@ module DefaultHostgroupManagedHostPatch
       Rails.logger.info "DefaultHostgroupMatch: #{hostname} added to #{new_hostgroup}"
 
       return host, result
+    end
+
+    def group_matches?(fact)
+      fact.each do |fact_name, fact_regex|
+        fact_regex.gsub!(/(\A\/|\/\z)/, '')
+        host_fact_value = host.facts_hash[fact_name]
+        Rails.logger.info "Fact = #{fact_name}"
+        Rails.logger.info "Regex = #{fact_regex}"
+        return true if Regexp.new(fact_regex).match(host_fact_value)
+      end
+      return false
+    end
+
+    def find_match(facts_map)
+      facts_map.each do |group, fact|
+        return Hostgroup.find_by_title(hostgroup) if group_matches?(fact) and valid_hostgroup?(group)
+      end
     end
 
     def valid_hostgroup?(hostgroup)

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -38,8 +38,16 @@ module DefaultHostgroupManagedHostPatch
 
       map = SETTINGS[:default_hostgroup][:map]
       facts_map = SETTINGS[:default_hostgroup][:facts_map]
-      Rails.logger.debug "Facts map contains #{facts_map}"
       new_hostgroup = nil
+
+
+      facts_map.each do |group, fact|
+        Rails.logger.debug "Hostgroup = #{group}"
+        fact.each do |fact_name, match|
+          Rails.logger.debug "Fact = #{fact_name}"
+          Rails.logger.debug "match = #{match}"
+        end
+      end
 
       map.each do |hostgroup, regex|
         unless valid_hostgroup?(hostgroup)

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -12,7 +12,7 @@ module DefaultHostgroupManagedHostPatch
     def import_host_and_facts_with_match_hostgroup hostname, facts, certname = nil, proxy_id = nil
       host, result = import_host_and_facts_without_match_hostgroup(hostname, facts, certname, proxy_id)
 
-      unless SETTINGS[:default_hostgroup] && SETTINGS[:default_hostgroup][:map]
+      unless SETTINGS[:default_hostgroup] && SETTINGS[:default_hostgroup][:map] || SETTINGS[:default_hostgroup][:facts_map]
         Rails.logger.warn "DefaultHostgroupMatch: Could not load default_hostgroup map from settings, check config."
         return host, result
       end

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -51,6 +51,9 @@ module DefaultHostgroupManagedHostPatch
         end
       end
 
+      facts_map = SETTINGS[:default_hostgroup][:facts_map]
+      Rails.logger.debug "Facts map contains #{facts_map}"
+
       return host, result unless new_hostgroup
 
       host.hostgroup = new_hostgroup

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -54,17 +54,19 @@ module DefaultHostgroupManagedHostPatch
       # end
 
       # Add some method for determining which match wins.
-      facts_map.each do |group, fact|
-        Rails.logger.info "Hostgroup = #{group}"
-        fact.each do |fact_name, fact_regex|
-          fact_regex.gsub!(/(\A\/|\/\z)/, '')
-          host_fact_value = host.facts_hash[fact_name]
-            Rails.logger.info "Fact = #{fact_name}"
-            Rails.logger.info "Regex = #{fact_regex}"
-          if Regexp.new(fact_regex).match(host_fact_value)
-            Rails.logger.info "#{host_fact_value} matches #{fact_regex}"
-            new_hostgroup = Hostgroup.find_by_title(group)
-            break
+      catch "FoundMatch"
+        facts_map.each do |group, fact|
+          Rails.logger.info "Hostgroup = #{group}"
+          fact.each do |fact_name, fact_regex|
+            fact_regex.gsub!(/(\A\/|\/\z)/, '')
+            host_fact_value = host.facts_hash[fact_name]
+              Rails.logger.info "Fact = #{fact_name}"
+              Rails.logger.info "Regex = #{fact_regex}"
+            if Regexp.new(fact_regex).match(host_fact_value)
+              Rails.logger.info "#{host_fact_value} matches #{fact_regex}"
+              new_hostgroup = Hostgroup.find_by_title(group)
+              throw "FoundMatch"
+            end
           end
         end
       end

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -54,7 +54,7 @@ module DefaultHostgroupManagedHostPatch
       # end
 
       # Add some method for determining which match wins.
-      catch "FoundMatch" do
+      catch (:foundmatch) do
         facts_map.each do |group, fact|
           Rails.logger.info "Hostgroup = #{group}"
           fact.each do |fact_name, fact_regex|
@@ -65,7 +65,7 @@ module DefaultHostgroupManagedHostPatch
             if Regexp.new(fact_regex).match(host_fact_value)
               Rails.logger.info "#{host_fact_value} matches #{fact_regex}"
               new_hostgroup = Hostgroup.find_by_title(group)
-              throw "FoundMatch"
+              throw :foundmatch
             end
           end
         end

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -38,6 +38,7 @@ module DefaultHostgroupManagedHostPatch
 
       facts_map = SETTINGS[:default_hostgroup][:facts_map]
       new_hostgroup = find_match(facts_map)
+      puts new_hostgroup.inspect
 
       return @host, result unless new_hostgroup
 

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -10,7 +10,7 @@ module DefaultHostgroupManagedHostPatch
 
   module ClassMethods
     def import_host_and_facts_with_match_hostgroup hostname, facts, certname = nil, proxy_id = nil
-      host, result = import_host_and_facts_without_match_hostgroup(hostname, facts, certname, proxy_id)
+      @host, result = import_host_and_facts_without_match_hostgroup(hostname, facts, certname, proxy_id)
 
       unless SETTINGS[:default_hostgroup] && SETTINGS[:default_hostgroup][:facts_map]
         Rails.logger.warn "DefaultHostgroupMatch: Could not load default_hostgroup map from settings, check config."

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -11,8 +11,8 @@ module DefaultHostgroupManagedHostPatch
   module ClassMethods
     def import_host_and_facts_with_match_hostgroup hostname, facts, certname = nil, proxy_id = nil
       host, result = import_host_and_facts_without_match_hostgroup(hostname, facts, certname, proxy_id)
-      Rails.logger.debug SETTINGS[:default_hostgroup][:map]
-      Rails.logger.debug SETTINGS[:default_hostgroup][:facts_map]
+      facts_map = SETTINGS[:default_hostgroup][:facts_map]
+      Rails.logger.debug "Facts Map contains #{facts_map}"
       unless SETTINGS[:default_hostgroup] && SETTINGS[:default_hostgroup][:map]
         Rails.logger.warn "DefaultHostgroupMatch: Could not load default_hostgroup map from settings, check config."
         return host, result
@@ -38,9 +38,6 @@ module DefaultHostgroupManagedHostPatch
       end
 
       map = SETTINGS[:default_hostgroup][:map]
-      facts_map = SETTINGS[:default_hostgroup][:facts_map]
-      Rails.logger.debug "Facts Map contains #{facts_map}"
-
       new_hostgroup = nil
 
       map.each do |hostgroup, regex|

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -40,15 +40,6 @@ module DefaultHostgroupManagedHostPatch
       facts_map = SETTINGS[:default_hostgroup][:facts_map]
       new_hostgroup = nil
 
-      Rails.logger.info "Trying to check facts_map settings..."
-      facts_map.each do |group, fact|
-        Rails.logger.info "Hostgroup = #{group}"
-        fact.each do |fact_name, match|
-          Rails.logger.info "Fact = #{fact_name}"
-          Rails.logger.info "match = #{match}"
-        end
-      end
-      Rails.logger.debug "Trying to check facts_map settings..."
 
       map.each do |hostgroup, regex|
         unless valid_hostgroup?(hostgroup)
@@ -62,7 +53,18 @@ module DefaultHostgroupManagedHostPatch
         end
       end
 
-
+      facts_map.each do |group, fact|
+        Rails.logger.info "Hostgroup = #{group}"
+        fact.each do |fact_name, fact_regex|
+          fact_regex.gsub!(/(\A\/|\/\z)/, '')
+          host_fact_value = host.facts_hash[fact_name]
+            Rails.logger.info "Fact = #{fact_name}"
+            Rails.logger.info "Regex = #{fact_regex}"
+          if Regexp.new(fact_regex).match(host_fact_value)
+            Rails.logger.info "#{host_fact_value} matches ${fact_regex}"
+          end
+        end
+      end
 
       return host, result unless new_hostgroup
 

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -40,7 +40,7 @@ module DefaultHostgroupManagedHostPatch
       facts_map = SETTINGS[:default_hostgroup][:facts_map]
       new_hostgroup = nil
 
-
+      Rails.logger.debug "Trying to check facts_map settings..."
       facts_map.each do |group, fact|
         Rails.logger.debug "Hostgroup = #{group}"
         fact.each do |fact_name, match|
@@ -48,6 +48,7 @@ module DefaultHostgroupManagedHostPatch
           Rails.logger.debug "match = #{match}"
         end
       end
+      Rails.logger.debug "Finished trying to check facts_map settings..."
 
       map.each do |hostgroup, regex|
         unless valid_hostgroup?(hostgroup)

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -37,6 +37,8 @@ module DefaultHostgroupManagedHostPatch
       end
 
       map = SETTINGS[:default_hostgroup][:map]
+      facts_map = SETTINGS[:default_hostgroup][:facts_map]
+      Rails.logger.debug "Facts map contains #{facts_map}"
       new_hostgroup = nil
 
       map.each do |hostgroup, regex|
@@ -51,8 +53,7 @@ module DefaultHostgroupManagedHostPatch
         end
       end
 
-      facts_map = SETTINGS[:default_hostgroup][:facts_map]
-      Rails.logger.debug "Facts map contains #{facts_map}"
+
 
       return host, result unless new_hostgroup
 

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -66,7 +66,7 @@ module DefaultHostgroupManagedHostPatch
           return Hostgroup.find_by_title(group_name)
         else
           Rails.logger.info "No match found for #{@host.name}"
-          return false
+          next
         end
       end
     end

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -61,13 +61,10 @@ module DefaultHostgroupManagedHostPatch
 
     def find_match(facts_map)
       facts_map.each do |group_name, facts|
-        if group_matches?(facts) and valid_hostgroup?(group_name)
-          return Hostgroup.find_by_title(group_name)
-        else
-          Rails.logger.info "No match found for #{@host.name}"
-          next
-        end
+        return Hostgroup.find_by_title(group_name) if group_matches?(facts) and valid_hostgroup?(group_name)
       end
+      Rails.logger.info "No match ..."
+      return false
     end
 
     def valid_hostgroup?(hostgroup)

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -37,6 +37,9 @@ module DefaultHostgroupManagedHostPatch
       end
 
       map = SETTINGS[:default_hostgroup][:map]
+      facts_map = SETTINGS[:default_hostgroup][:facts_map]
+      Rails.logger.debug "Facts Map contains #{facts_map}"
+
       new_hostgroup = nil
 
       map.each do |hostgroup, regex|

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -40,15 +40,15 @@ module DefaultHostgroupManagedHostPatch
       facts_map = SETTINGS[:default_hostgroup][:facts_map]
       new_hostgroup = nil
 
-      Rails.logger.debug "Trying to check facts_map settings..."
+      Rails.logger.info "Trying to check facts_map settings..."
       facts_map.each do |group, fact|
-        Rails.logger.debug "Hostgroup = #{group}"
+        Rails.logger.info "Hostgroup = #{group}"
         fact.each do |fact_name, match|
-          Rails.logger.debug "Fact = #{fact_name}"
-          Rails.logger.debug "match = #{match}"
+          Rails.logger.info "Fact = #{fact_name}"
+          Rails.logger.info "match = #{match}"
         end
       end
-      Rails.logger.debug "Finished trying to check facts_map settings..."
+      Rails.logger.debug "Trying to check facts_map settings..."
 
       map.each do |hostgroup, regex|
         unless valid_hostgroup?(hostgroup)

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -14,7 +14,7 @@ module DefaultHostgroupManagedHostPatch
 
       unless SETTINGS[:default_hostgroup] && SETTINGS[:default_hostgroup][:facts_map]
         Rails.logger.warn "DefaultHostgroupMatch: Could not load default_hostgroup map from settings, check config."
-        return host, result
+        return @host, result
       end
 
       Rails.logger.debug "DefaultHostgroupMatch: performing Hostgroup match"
@@ -22,36 +22,36 @@ module DefaultHostgroupManagedHostPatch
       if Setting[:force_hostgroup_match_only_new]
         # host.new_record? will only test for the early return in the core method, a real host
         # will have already been saved at least once.
-        unless host.present? && !host.new_record? && host.hostgroup.nil? && host.reports.empty?
+        unless @host.present? && !@host.new_record? && @host.hostgroup.nil? && @host.reports.empty?
 
           Rails.logger.debug "DefaultHostgroupMatch: skipping, host exists"
-          return host, result
+          return @host, result
         end
       end
 
       unless Setting[:force_hostgroup_match]
-        if host.hostgroup.present?
+        if @host.hostgroup.present?
           Rails.logger.debug "DefaultHostgroupMatch: skipping, host has hostgroup"
-          return host, result
+          return @host, result
         end
       end
 
       facts_map = SETTINGS[:default_hostgroup][:facts_map]
       new_hostgroup = find_match(facts_map)
 
-      return host, result unless new_hostgroup
+      return @host, result unless new_hostgroup
 
-      host.hostgroup = new_hostgroup
-      host.save(:validate => false)
+      @host.hostgroup = new_hostgroup
+      @host.save(:validate => false)
       Rails.logger.info "DefaultHostgroupMatch: #{hostname} added to #{new_hostgroup}"
 
-      return host, result
+      return @host, result
     end
 
     def group_matches?(fact)
       fact.each do |fact_name, fact_regex|
         fact_regex.gsub!(/(\A\/|\/\z)/, '')
-        host_fact_value = host.facts_hash[fact_name]
+        host_fact_value = @host.facts_hash[fact_name]
         Rails.logger.info "Fact = #{fact_name}"
         Rails.logger.info "Regex = #{fact_regex}"
         return true if Regexp.new(fact_regex).match(host_fact_value)

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -12,7 +12,7 @@ module DefaultHostgroupManagedHostPatch
     def import_host_and_facts_with_match_hostgroup hostname, facts, certname = nil, proxy_id = nil
       host, result = import_host_and_facts_without_match_hostgroup(hostname, facts, certname, proxy_id)
 
-      unless SETTINGS[:default_hostgroup] && SETTINGS[:default_hostgroup][:map] || SETTINGS[:default_hostgroup][:facts_map]
+      unless SETTINGS[:default_hostgroup] && SETTINGS[:default_hostgroup][:facts_map]
         Rails.logger.warn "DefaultHostgroupMatch: Could not load default_hostgroup map from settings, check config."
         return host, result
       end
@@ -36,23 +36,24 @@ module DefaultHostgroupManagedHostPatch
         end
       end
 
-      map = SETTINGS[:default_hostgroup][:map]
+      # map = SETTINGS[:default_hostgroup][:map]
       facts_map = SETTINGS[:default_hostgroup][:facts_map]
       new_hostgroup = nil
 
 
-      map.each do |hostgroup, regex|
-        unless valid_hostgroup?(hostgroup)
-          Rails.logger.error "DefaultHostgroupMatch: #{hostgroup} is not a valid hostgroup, skipping."
-          next
-        end
-        regex.gsub!(/(\A\/|\/\z)/, '')
-        if Regexp.new(regex).match(hostname)
-          new_hostgroup = Hostgroup.find_by_title(hostgroup)
-          break
-        end
-      end
+      # map.each do |hostgroup, regex|
+      #   unless valid_hostgroup?(hostgroup)
+      #     Rails.logger.error "DefaultHostgroupMatch: #{hostgroup} is not a valid hostgroup, skipping."
+      #     next
+      #   end
+      #   regex.gsub!(/(\A\/|\/\z)/, '')
+      #   if Regexp.new(regex).match(hostname)
+      #     new_hostgroup = Hostgroup.find_by_title(hostgroup)
+      #     break
+      #   end
+      # end
 
+      # Add some method for determining which match wins.
       facts_map.each do |group, fact|
         Rails.logger.info "Hostgroup = #{group}"
         fact.each do |fact_name, fact_regex|
@@ -62,6 +63,8 @@ module DefaultHostgroupManagedHostPatch
             Rails.logger.info "Regex = #{fact_regex}"
           if Regexp.new(fact_regex).match(host_fact_value)
             Rails.logger.info "#{host_fact_value} matches #{fact_regex}"
+            new_hostgroup = Hostgroup.find_by_title(group)
+            break
           end
         end
       end

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -65,8 +65,8 @@ module DefaultHostgroupManagedHostPatch
             if Regexp.new(fact_regex).match(host_fact_value)
               Rails.logger.info "#{host_fact_value} matches #{fact_regex}"
               new_hostgroup = Hostgroup.find_by_title(group)
-              throw :foundmatch
             end
+            throw :foundmatch if new_hostgroup
           end
         end
       end

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -61,8 +61,8 @@ module DefaultHostgroupManagedHostPatch
     end
 
     def find_match(facts_map)
-      facts_map.each do |group, fact|
-        return Hostgroup.find_by_title(group) if group_matches?(fact) and valid_hostgroup?(group)
+      facts_map.each do |group, facts|
+        return Hostgroup.find_by_title(group) if group_matches?(facts) and valid_hostgroup?(group)
       end
     end
 

--- a/test/unit/default_hostgroup_test.rb
+++ b/test/unit/default_hostgroup_test.rb
@@ -46,7 +46,7 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
     assert_equal hostgroup, Host.find_by_name('sinn1636.lan').hostgroup
   end
 
-  test "invalid hostgroup does nothing" do
+  test "invalid hostgroup name is ignored" do
     setup_hostgroup_match
     SETTINGS[:default_hostgroup][:facts_map] = { "Nonexistent Group" => {'hostname' => '.*'}, "Existent Group" => {'hostname' => '/\.lan$/'} }
 

--- a/test/unit/default_hostgroup_test.rb
+++ b/test/unit/default_hostgroup_test.rb
@@ -59,7 +59,7 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
 
   test "default hostgroup" do
     setup_hostgroup_match
-    SETTINGS[:default_hostgroup][:facts_map] = { "Test Default" => '.*' }
+    SETTINGS[:default_hostgroup][:facts_map] = { "Test Default" => {'hostname' =>'.*'} }
 
     hostgroup = Hostgroup.create(:name => "Test Default")
     raw = parse_json_fixture('/facts.json')
@@ -70,7 +70,7 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
 
   test "host already has a hostgroup" do
     setup_hostgroup_match
-    SETTINGS[:default_hostgroup][:facts_map] = { "Test Default" => '.*' }
+    SETTINGS[:default_hostgroup][:facts_map] = { "Test Default" => {'hostname' => '.*'} }
 
     hostgroup = Hostgroup.create(:name => "Test Group")
     Hostgroup.create(:name => "Test Default")
@@ -88,7 +88,7 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
     setup_hostgroup_match
     Setting[:force_hostgroup_match] = true
     Setting[:force_hostgroup_match_only_new] = false
-    SETTINGS[:default_hostgroup][:facts_map] = { "Test Default" => '.*' }
+    SETTINGS[:default_hostgroup][:facts_map] = { "Test Default" => {'hostname' => '.*'} }
 
     hostgroup = Hostgroup.create(:name => "Test Group")
     default = Hostgroup.create(:name => "Test Default")
@@ -105,7 +105,7 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
   test "hostgroup is not updated if host is not new" do
     setup_hostgroup_match
     Setting[:force_hostgroup_match] = true
-    SETTINGS[:default_hostgroup][:facts_map] = { "Test Default" => '.*' }
+    SETTINGS[:default_hostgroup][:facts_map] = { "Test Default" => {'hostname' => '.*'} }
 
     hostgroup = Hostgroup.create(:name => "Test Group")
     Hostgroup.create(:name => "Test Default")

--- a/test/unit/default_hostgroup_test.rb
+++ b/test/unit/default_hostgroup_test.rb
@@ -37,7 +37,7 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
 
   test "partial matching regex enclosed in /" do
     setup_hostgroup_match
-    SETTINGS[:default_hostgroup][:facts_map] = { "Test Partial" => '/\.lan$/' }
+    SETTINGS[:default_hostgroup][:facts_map] = { "Test Partial" => {'hostname' => '/\.lan$/' }}
 
     hostgroup = Hostgroup.create(:name => "Test Partial")
     raw = parse_json_fixture('/facts.json')
@@ -48,7 +48,7 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
 
   test "invalid hostgroup does nothing" do
     setup_hostgroup_match
-    SETTINGS[:default_hostgroup][:facts_map] = { "Nonexistent Group" => '.*', "Existent Group" => '/\.lan$/' }
+    SETTINGS[:default_hostgroup][:facts_map] = { "Nonexistent Group" => {'hostname' => '.*'}, "Existent Group" => {'hostname' => '/\.lan$/'} }
 
     hostgroup = Hostgroup.create(:name => "Existent Group")
     raw = parse_json_fixture('/facts.json')

--- a/test/unit/default_hostgroup_test.rb
+++ b/test/unit/default_hostgroup_test.rb
@@ -57,6 +57,17 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
     assert_equal hostgroup, Host.find_by_name('sinn1636.lan').hostgroup
   end
 
+  test "first matching hostgroup is used" do
+    setup_hostgroup_match
+    SETTINGS[:default_hostgroup][:facts_map] = { "First Group" => {'hostname' => '.*'}, "Second Group" => {'hostname' => '.*'} }
+
+    hostgroup = Hostgroup.create(:name => "First Group")
+    raw = parse_json_fixture('/facts.json')
+
+    assert Host.import_host_and_facts(raw['name'], raw['facts'])
+    assert_equal hostgroup, Host.find_by_name('sinn1636.lan').hostgroup
+  end
+
   test "default hostgroup" do
     setup_hostgroup_match
     SETTINGS[:default_hostgroup][:facts_map] = { "Test Default" => {'hostname' =>'.*'} }

--- a/test/unit/default_hostgroup_test.rb
+++ b/test/unit/default_hostgroup_test.rb
@@ -68,6 +68,28 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
     assert_equal hostgroup, Host.find_by_name('sinn1636.lan').hostgroup
   end
 
+  test "invalid keys ignored" do
+    setup_hostgroup_match
+    SETTINGS[:default_hostgroup][:facts_map] = { "First Group" => {'nosuchfact' => '.*', 'hostname' => '.*'} }
+
+    hostgroup = Hostgroup.create(:name => "First Group")
+    raw = parse_json_fixture('/facts.json')
+
+    assert Host.import_host_and_facts(raw['name'], raw['facts'])
+    assert_equal hostgroup, Host.find_by_name('sinn1636.lan').hostgroup
+  end
+
+  test "unmatched values ignored" do
+    setup_hostgroup_match
+    SETTINGS[:default_hostgroup][:facts_map] = { "First Group" => {'hostname' => 'nosuchname', 'osfamily' => '.*'} }
+
+    hostgroup = Hostgroup.create(:name => "First Group")
+    raw = parse_json_fixture('/facts.json')
+
+    assert Host.import_host_and_facts(raw['name'], raw['facts'])
+    assert_equal hostgroup, Host.find_by_name('sinn1636.lan').hostgroup
+  end
+
   test "default hostgroup" do
     setup_hostgroup_match
     SETTINGS[:default_hostgroup][:facts_map] = { "Test Default" => {'hostname' =>'.*'} }

--- a/test/unit/default_hostgroup_test.rb
+++ b/test/unit/default_hostgroup_test.rb
@@ -26,7 +26,7 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
 
   test "full matching regex not enclosed in /" do
     setup_hostgroup_match
-    SETTINGS[:default_hostgroup][:map] = { "Test Full" => '^sinn1636.lan$' }
+    SETTINGS[:default_hostgroup][:facts_map] = { "Test Full" => {'hostname' =>'^sinn1636.lan$'} }
 
     hostgroup = Hostgroup.create(:name => "Test Full")
     raw = parse_json_fixture('/facts.json')
@@ -37,7 +37,7 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
 
   test "partial matching regex enclosed in /" do
     setup_hostgroup_match
-    SETTINGS[:default_hostgroup][:map] = { "Test Partial" => '/\.lan$/' }
+    SETTINGS[:default_hostgroup][:facts_map] = { "Test Partial" => '/\.lan$/' }
 
     hostgroup = Hostgroup.create(:name => "Test Partial")
     raw = parse_json_fixture('/facts.json')
@@ -48,7 +48,7 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
 
   test "invalid hostgroup does nothing" do
     setup_hostgroup_match
-    SETTINGS[:default_hostgroup][:map] = { "Nonexistent Group" => '.*', "Existent Group" => '/\.lan$/' }
+    SETTINGS[:default_hostgroup][:facts_map] = { "Nonexistent Group" => '.*', "Existent Group" => '/\.lan$/' }
 
     hostgroup = Hostgroup.create(:name => "Existent Group")
     raw = parse_json_fixture('/facts.json')
@@ -59,7 +59,7 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
 
   test "default hostgroup" do
     setup_hostgroup_match
-    SETTINGS[:default_hostgroup][:map] = { "Test Default" => '.*' }
+    SETTINGS[:default_hostgroup][:facts_map] = { "Test Default" => '.*' }
 
     hostgroup = Hostgroup.create(:name => "Test Default")
     raw = parse_json_fixture('/facts.json')
@@ -70,7 +70,7 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
 
   test "host already has a hostgroup" do
     setup_hostgroup_match
-    SETTINGS[:default_hostgroup][:map] = { "Test Default" => '.*' }
+    SETTINGS[:default_hostgroup][:facts_map] = { "Test Default" => '.*' }
 
     hostgroup = Hostgroup.create(:name => "Test Group")
     Hostgroup.create(:name => "Test Default")
@@ -88,7 +88,7 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
     setup_hostgroup_match
     Setting[:force_hostgroup_match] = true
     Setting[:force_hostgroup_match_only_new] = false
-    SETTINGS[:default_hostgroup][:map] = { "Test Default" => '.*' }
+    SETTINGS[:default_hostgroup][:facts_map] = { "Test Default" => '.*' }
 
     hostgroup = Hostgroup.create(:name => "Test Group")
     default = Hostgroup.create(:name => "Test Default")
@@ -105,7 +105,7 @@ class DefaultHostgroupTest < ActiveSupport::TestCase
   test "hostgroup is not updated if host is not new" do
     setup_hostgroup_match
     Setting[:force_hostgroup_match] = true
-    SETTINGS[:default_hostgroup][:map] = { "Test Default" => '.*' }
+    SETTINGS[:default_hostgroup][:facts_map] = { "Test Default" => '.*' }
 
     hostgroup = Hostgroup.create(:name => "Test Group")
     Hostgroup.create(:name => "Test Default")

--- a/test/unit/facts.json
+++ b/test/unit/facts.json
@@ -26,7 +26,7 @@
     "serialnumber": "abcdefg",
     "processor7": "Intel(R) Xeon(R) CPU           E5620  @ 2.40GHz",
     "macaddress_vnet4": "FE:54:00:62:53:67",
-    "hostname": "h02",
+    "hostname": "sinn1636.lan",
     "osfamily": "RedHat",
     "gateway_if": "br180",
     "lsbrelease": ":core-4.0-amd64:core-4.0-noarch:graphics-4.0-amd64:graphics-4.0-noarch:printing-4.0-amd64:printing-4.0-noarch",


### PR DESCRIPTION
This change would allow the use of a regex against any given fact rather that just the hostname of the machine. 

The first match found  as listed in the config would be applied to the machine. As ruby 1.9.x retains the order of a hash read from config, this should be a reliable way of establishing the priority.

Eventually I would like to perhaps do compound comparisons (If factA = regex and FactB = regex), but this seems like a good start.

Open to any and all suggestions!
