### PR TITLE
Upgrading from 2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ your needs. The format is shown in the example. The simplest form would be:
     "Default":
       "hostname": ".*"
 ```
+If you are ugrading from plugin version 2.0.1 or older the format of this
+file changes and you will need modify `default_hostgroup.yaml.example` to
+follow the format above.
 
 *Important Note:* You have to restart foreman in order to apply changes in
 `default_hostgroup.yaml`!


### PR DESCRIPTION
When upgrading from 2.0.1 the default_hostgroup.yaml remains in the older format and consequently will no longer place hosts into default group.  I found this when upgrading from Foreman 1.5 to 1.7 on Ubuntu 12.04.
