### PR TITLE
adds ability to specify multiple regex strings for a single fact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 # Need a config/environment.rb for rails.vim to work in engines
 config/environment.rb
+test/foreman_app
 *gem
+.idea
+.bundle

--- a/README.md
+++ b/README.md
@@ -37,13 +37,32 @@ your needs. The format is shown in the example. The simplest form would be:
 *Important Note:* You have to restart foreman in order to apply changes in
 `default_hostgroup.yaml`!
 
-There are also two more settings under `Settings -> DefaultHostgroup`
+There are also two more settings under the Foreman UI `Settings -> DefaultHostgroup`
 
 | Setting | Description |
 | ------- | ----------- |
 | `force_hostgroup_match` | Setting this to `true` will perform matching even on hosts that already have a hostgroup set. Enabling this needs `force_hostgroup_match_only_new` to be `false`.  Default: `false` |
 | `force_hostgroup_match_only_new` | Setting this to `true` will only perform matching when a host uploads its facts for the first time, i.e. after provisioning or when adding an existing puppetmaster and thus its nodes into foreman. Default: `true` |
 
+### Multiple Regex matching
+Sometimes you will have complex regex matching patterns that you may want to split out into multiple regex strings.
+In order to do this you must put regex strings inside an array.  It doesn't matter if the string contains
+the forward slashes or not for each regex inside the array.
+
+Example
+
+```ruby
+  ---
+  :default_hostgroup:
+    :facts_map:
+      "Go_agents":
+        "hostname":
+          - "go_agent1"
+          - "go_agent2"
+          - "go_agent[1][1-3]"
+      "Default":
+        "hostname": ".*"
+```
 ## TODO
 
 * Deface the Hostgroup UI to add the regular expressions directly into the Hostgroup
@@ -51,6 +70,10 @@ There are also two more settings under `Settings -> DefaultHostgroup`
 ## Contributing
 
 Fork and send me a Pull Request. Thanks!
+
+### Testing
+For running the tests, see http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Testing
+in short, add the plugin to a normal Foreman source install and run "rake test" or "rake test:default_hostgroup"
 
 ## Copyright
 

--- a/default_hostgroup.yaml.example
+++ b/default_hostgroup.yaml.example
@@ -18,6 +18,11 @@
 ---
 :default_hostgroup:
   :facts_map:
+    "Go_agents":
+      "hostname":
+        - "go_agent1"
+        - "go_agent2"
+        - "go_agent[1][1-3]"
     "Redhat":
       "osfamily": "RedHat"
       "lsbdistcodename": "Santiago"

--- a/lib/default_hostgroup_managed_host_patch.rb
+++ b/lib/default_hostgroup_managed_host_patch.rb
@@ -50,11 +50,13 @@ module DefaultHostgroupManagedHostPatch
 
     def group_matches?(fact)
       fact.each do |fact_name, fact_regex|
-        fact_regex.gsub!(/(\A\/|\/\z)/, '')
         host_fact_value = @host.facts_hash[fact_name]
-        Rails.logger.info "Fact = #{fact_name}"
-        Rails.logger.info "Regex = #{fact_regex}"
-        return true if Regexp.new(fact_regex).match(host_fact_value)
+        Array(fact_regex).each do |f_regex|
+          f_regex.gsub!(/(\A\/|\/\z)/, '')
+          Rails.logger.info "Fact = #{fact_name}"
+          Rails.logger.info "Regex = #{f_regex}"
+          return true if Regexp.new(f_regex).match(host_fact_value)
+        end
       end
       return false
     end


### PR DESCRIPTION
- previously if you wanted to match multiple hosts across a large network
  your regex pattern has to be extremely crafty.  With this feature
  you can now supply multiple regex values to match against, thus making your regex
  patterns more trivial.
