### PR TITLE
Add "exact_hostgroup_match" switch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 config/environment.rb
 *gem
 *swp
+.idea

--- a/app/models/setting/default_hostgroup.rb
+++ b/app/models/setting/default_hostgroup.rb
@@ -10,7 +10,8 @@ class Setting::DefaultHostgroup < ::Setting
       [
         set('force_hostgroup_match', 'Apply hostgroup matching even if a host already has one.', false),
         set('force_hostgroup_match_only_new', 'Apply hostgroup matching only on new hosts', true),
-        set('force_host_environment', "Apply hostgroup's environment to host even if a host already has a different one", true)
+        set('force_host_environment', "Apply hostgroup's environment to host even if a host already has a different one", true),
+        set('exact_hostgroup_match', 'Match hostgroup names to fact values exactly without the regular expression', false)
       ].compact.each { |s| create s.update(category: 'Setting::DefaultHostgroup') }
     end
 

--- a/lib/default_hostgroup_base_host_patch.rb
+++ b/lib/default_hostgroup_base_host_patch.rb
@@ -41,12 +41,17 @@ module DefaultHostgroupBaseHostPatch
   end
 
   def group_matches?(facts)
-    facts.each do |fact_name, fact_regex|
-      fact_regex.gsub!(%r{(\A/|/\z)}, '')
+    facts.each do |fact_name, node_fact_value|
       host_fact_value = facts_hash[fact_name]
       Rails.logger.info "Fact = #{fact_name}"
-      Rails.logger.info "Regex = #{fact_regex}"
-      return true if Regexp.new(fact_regex).match(host_fact_value)
+      if Setting[:exact_hostgroup_match]
+        Rails.logger.info "Value = #{node_fact_value}"
+        return true if node_fact_value == host_fact_value
+      else
+        node_fact_value.gsub!(%r{(\A/|/\z)}, '')
+        Rails.logger.info "Regex = #{node_fact_value}"
+        return true if Regexp.new(node_fact_value).match(host_fact_value)
+      end
     end
     false
   end


### PR DESCRIPTION
Match the hostgroup names to the fact values exactly without
using the regular expression.

Gives the user option to disable regex matching of the hostgroups. It can be useful
if the hostgroup names contain special chars or include each other.