### PR TITLE
Update engine.rb

### DIFF
--- a/lib/foreman_default_hostgroup/engine.rb
+++ b/lib/foreman_default_hostgroup/engine.rb
@@ -13,7 +13,7 @@ module ForemanDefaultHostgroup
 
     initializer 'foreman_default_hostgroup.register_plugin',
                 before: :finisher_hook do
-      Foreman::Plugin.register :foreman_plugin_template do
+      Foreman::Plugin.register :foreman_default_hostgroup do
         requires_foreman '>= 1.12'
       end
     end


### PR DESCRIPTION
foreman_plugin_template not found by Foreman 1.16.0
Modify foreman_plugin_template to foreman_default_hostgroup