### PR TITLE
Update to Module#prepend and fix tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 config/environment.rb
 *gem
 *swp
+.ruby-version

--- a/lib/default_hostgroup_base_host_patch.rb
+++ b/lib/default_hostgroup_base_host_patch.rb
@@ -1,11 +1,22 @@
 module DefaultHostgroupBaseHostPatch
   extend ActiveSupport::Concern
 
+  module ManagedOverrides
+    def import_facts(facts, source_proxy = nil, without = false)
+      super(facts, source_proxy)
+    end
+  end
+
   module Overrides
-    def import_facts(facts, source_proxy = nil)
+    def import_facts(facts, source_proxy = nil, without_alias = false)
       # Load the facts anyway, hook onto the end of it
       result = super(facts, source_proxy)
 
+      # Module#prepend removes the import_facts_without_match_hostgroup method, so use
+      # a flag to return here if needed
+      return result if without_alias
+
+      # Check settings are created
       return result unless settings_exist?
 
       Rails.logger.debug 'DefaultHostgroupMatch: performing Hostgroup match'

--- a/lib/foreman_default_hostgroup/engine.rb
+++ b/lib/foreman_default_hostgroup/engine.rb
@@ -1,11 +1,10 @@
 require 'default_hostgroup_base_host_patch'
 
 module ForemanDefaultHostgroup
-  # Inherit from the Rails module of the parent app (Foreman), not
-  # the plugin. Thus, inherits from ::Rails::Engine and not from
-  # Rails::Engine
   class Engine < ::Rails::Engine
     engine_name 'foreman_default_hostgroup'
+
+    config.autoload_paths += Dir["#{config.root}/app/models"]
 
     initializer 'foreman_default_hostgroup.load_default_settings',
                 before: :load_config_initializers do
@@ -16,20 +15,18 @@ module ForemanDefaultHostgroup
     initializer 'foreman_default_hostgroup.register_plugin',
                 before: :finisher_hook do
       Foreman::Plugin.register :foreman_default_hostgroup do
-        requires_foreman '>= 1.12'
+        requires_foreman '>= 1.17'
       end
     end
 
     config.to_prepare do
       begin
         ::Host::Base.send(:include, DefaultHostgroupBaseHostPatch)
+        ::Host::Managed.send(:prepend, DefaultHostgroupBaseHostPatch::ManagedOverrides)
       rescue => e
         Rails.logger.warn "ForemanDefaultHostgroup: skipping engine hook (#{e})"
       end
     end
 
-    rake_tasks do
-      load 'default_hostgroup.rake'
-    end
   end
 end

--- a/lib/tasks/foreman_default_hostgroup.rake
+++ b/lib/tasks/foreman_default_hostgroup.rake
@@ -1,11 +1,13 @@
+require 'rake/testtask'
 # Tests
 namespace :test do
   desc "Test DefaultHostgroup plugin"
   Rake::TestTask.new(:foreman_default_hostgroup) do |t|
-    test_dir = File.join(File.dirname(__FILE__), '..', 'test')
-    t.libs << ["test",test_dir]
+    test_dir = File.join(File.dirname(__FILE__), '../..', 'test')
+    t.libs << ['test', test_dir]
     t.pattern = "#{test_dir}/**/*_test.rb"
     t.verbose = true
+    t.warning = false
   end
 end
 

--- a/test/test_plugin_helper.rb
+++ b/test/test_plugin_helper.rb
@@ -1,6 +1,6 @@
 # This calls the main test_helper in Foreman-core
 require 'test_helper'
 
-# Add plugin to FactoryGirl's paths
-FactoryGirl.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
-FactoryGirl.reload
+# Add plugin to FactoryBot's paths
+FactoryBot.definition_file_paths << File.join(File.dirname(__FILE__), 'factories')
+FactoryBot.reload


### PR DESCRIPTION
Includes #36 (thanks @dasmall80!) as well as the needed changes to the tests. All current tests now pass.

@tbrisker / @bastilian / anyone :P - can you suggest a better way of handling the access to (now missing) `import_facts_without_match_hostgroup`? The `*args` hack I'm using here is *awful*.