### PR TITLE
Add support for foreman 2.2.0 and the HostFactImporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,16 @@ See Foreman's [plugin installation documentation](https://theforeman.org/plugins
 ## Compatibility
 
 | Foreman Version | Plugin Version |
-| --------------- | --------------:|
-| <= 1.2          | 0.1.0          |
-|    1.3          | 1.0.1          |
-|    1.4          | 1.1.0          |
-|    1.5          | 2.0.1          |
-|    1.6 - 1.11   | 3.0.0          |
-| >= 1.12         | 4.0.0          |
-| >= 1.16         | 4.0.1          |
-| >= 1.16         | 5.0.0          |
+| --------------- | -------------: |
+| <= 1.2          |          0.1.0 |
+| 1.3             |          1.0.1 |
+| 1.4             |          1.1.0 |
+| 1.5             |          2.0.1 |
+| 1.6 - 1.11      |          3.0.0 |
+| >= 1.12         |          4.0.0 |
+| >= 1.16         |          4.0.1 |
+| >= 1.16         |          5.0.0 |
+| >= 2.2.0        |          6.0.0 |
 
 ## Usage
 
@@ -44,9 +45,9 @@ follow the format above.
 
 There are also two more settings under `Settings -> DefaultHostgroup`
 
-| Setting | Description |
-| ------- | ----------- |
-| `force_hostgroup_match` | Setting this to `true` will perform matching even on hosts that already have a hostgroup set. Enabling this needs `force_hostgroup_match_only_new` to be `false`.  Default: `false` |
+| Setting                          | Description                                                                                                                                                                                                          |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `force_hostgroup_match`          | Setting this to `true` will perform matching even on hosts that already have a hostgroup set. Enabling this needs `force_hostgroup_match_only_new` to be `false`.  Default: `false`                                  |
 | `force_hostgroup_match_only_new` | Setting this to `true` will only perform matching when a host uploads its facts for the first time, i.e. after provisioning or when adding an existing puppetmaster and thus its nodes into foreman. Default: `true` |
 
 ## TODO

--- a/lib/default_hostgroup_base_host_patch.rb
+++ b/lib/default_hostgroup_base_host_patch.rb
@@ -79,7 +79,7 @@ module DefaultHostgroupBaseHostPatch
     if Setting[:force_hostgroup_match_only_new]
       # hosts have already been saved during import_host, so test the creation age instead
       new_host = ((Time.current - self.host.created_at) < 300)
-      unless new_host && hostgroup.nil? && self.host.reports.empty?
+      unless new_host && self.host.hostgroup.nil? && self.host.reports.empty?
         Rails.logger.debug "DefaultHostgroupMatch: skipping, host exists"
         return false
       end

--- a/lib/default_hostgroup_base_host_patch.rb
+++ b/lib/default_hostgroup_base_host_patch.rb
@@ -78,7 +78,7 @@ module DefaultHostgroupBaseHostPatch
   def host_new_or_forced?
     if Setting[:force_hostgroup_match_only_new]
       # hosts have already been saved during import_host, so test the creation age instead
-      new_host = ((Time.current - created_at) < 300)
+      new_host = ((Time.current - self.host.created_at) < 300)
       unless new_host && hostgroup.nil? && self.host.reports.empty?
         Rails.logger.debug "DefaultHostgroupMatch: skipping, host exists"
         return false

--- a/lib/foreman_default_hostgroup/engine.rb
+++ b/lib/foreman_default_hostgroup/engine.rb
@@ -16,7 +16,7 @@ module ForemanDefaultHostgroup
     initializer "foreman_default_hostgroup.register_plugin",
                 before: :finisher_hook do
       Foreman::Plugin.register :foreman_default_hostgroup do
-        requires_foreman ">= 2.0"
+        requires_foreman ">= 2.2"
       end
     end
 

--- a/lib/foreman_default_hostgroup/engine.rb
+++ b/lib/foreman_default_hostgroup/engine.rb
@@ -1,29 +1,29 @@
-require 'default_hostgroup_base_host_patch'
+require "default_hostgroup_base_host_patch"
 
 module ForemanDefaultHostgroup
   class Engine < ::Rails::Engine
-    engine_name 'foreman_default_hostgroup'
+    engine_name "foreman_default_hostgroup"
 
     config.autoload_paths += Dir["#{config.root}/app/models"]
 
-    initializer 'foreman_default_hostgroup.load_default_settings',
+    initializer "foreman_default_hostgroup.load_default_settings",
                 before: :load_config_initializers do
       require_dependency File.expand_path(
-        '../../app/models/setting/default_hostgroup.rb', __dir__
+        "../../app/models/setting/default_hostgroup.rb", __dir__
       )
     end
 
-    initializer 'foreman_default_hostgroup.register_plugin',
+    initializer "foreman_default_hostgroup.register_plugin",
                 before: :finisher_hook do
       Foreman::Plugin.register :foreman_default_hostgroup do
-        requires_foreman '>= 1.17'
+        requires_foreman ">= 2.0"
       end
     end
 
     config.to_prepare do
       begin
-        ::Host::Base.include DefaultHostgroupBaseHostPatch
-        ::Host::Managed.prepend DefaultHostgroupBaseHostPatch::ManagedOverrides
+        ::HostFactImporter.include DefaultHostgroupBaseHostPatch
+        ::HostFactImporter.prepend DefaultHostgroupBaseHostPatch::ManagedOverrides
       rescue StandardError => e
         Rails.logger.warn "ForemanDefaultHostgroup: skipping engine hook (#{e})"
       end

--- a/lib/foreman_default_hostgroup/version.rb
+++ b/lib/foreman_default_hostgroup/version.rb
@@ -1,3 +1,3 @@
 module ForemanDefaultHostgroup
-  VERSION = '5.0.0'.freeze
+  VERSION = '6.0.0'.freeze
 end


### PR DESCRIPTION
Foreman since 2.2.0 has been updated to use a new HostFactImporter class and import_facts was moved to it.  Since the API no longer calls Host.import_facts directly the default_hostgroup plugin was not being called.  These changes refactor the plugin to use the HostFactImporter.

See [foreman commit 5253d21ed7d690e80e595a075d06f96d2e211e8c](https://github.com/theforeman/foreman/commit/5253d21ed7d690e80e595a075d06f96d2e211e8c#diff-bf26befb10d2696a3b87b8a034f1373fa2efcc69277f83c1101e1a529e35f1ea) for the foreman changes