### PR TITLE
Drop unsupported migration

### DIFF
--- a/db/migrate/20221103122801_fix_default_hostgroup_settings_category_to_dsl.rb
+++ b/db/migrate/20221103122801_fix_default_hostgroup_settings_category_to_dsl.rb
@@ -2,8 +2,6 @@
 
 class FixDefaultHostgroupSettingsCategoryToDsl < ActiveRecord::Migration[6.0]
   def up
-    # rubocop:disable Rails/SkipsModelValidations
-    Setting.where(category: 'Setting::DefaultHostgroup').update_all(category: 'Setting')
-    # rubocop:enable Rails/SkipsModelValidations
+    # historical placeholder, this is no longer needed
   end
 end


### PR DESCRIPTION
Introduced in cbf79fe7e8a63624a39bc77d07d0e60d9166a78c to fix issues after migration to setting DSL, but since Foreman 3.6 this is no longer needed.
The category column was dropped in https://github.com/theforeman/foreman/pull/9524

Fixing #59

@evgeni @ares any takers? :pray: 