### PR TITLE
Don't fail migration on Foreman 3.6+ without settings.category column

### DIFF
--- a/db/migrate/20221103122801_fix_default_hostgroup_settings_category_to_dsl.rb
+++ b/db/migrate/20221103122801_fix_default_hostgroup_settings_category_to_dsl.rb
@@ -3,7 +3,7 @@
 class FixDefaultHostgroupSettingsCategoryToDsl < ActiveRecord::Migration[6.0]
   def up
     # rubocop:disable Rails/SkipsModelValidations
-    Setting.where(category: 'Setting::DefaultHostgroup').update_all(category: 'Setting')
+    Setting.where(category: 'Setting::DefaultHostgroup').update_all(category: 'Setting') if column_exists?(:settings, :category)
     # rubocop:enable Rails/SkipsModelValidations
   end
 end


### PR DESCRIPTION
Added check for column existance as settings.category was removed a while ago and this db:migrate rake fails.

Same fix has been applied to many modules before. For example here: https://github.com/theforeman/foreman_monitoring/commit/f7aca842acedf1f053d4127c064782548546e147